### PR TITLE
Cleanup page header component

### DIFF
--- a/app/components/common/pageHeader/pageHeader.html
+++ b/app/components/common/pageHeader/pageHeader.html
@@ -1,3 +1,3 @@
 <h1 class="cfa-pageHeader-title">{{vm.pageTitle}}</h1>
-<h2 class="cfa-pageHeader-subtitle">{{vm.pageSubtitle}}</h2>
-<p class="cfa-pageHeader-nextElection">Next Election: {{vm.nextElectionDate}}</p>
+<h2 ng-if="vm.pageSubtitle" class="cfa-pageHeader-subtitle">{{vm.pageSubtitle}}</h2>
+<p ng-if="vm.nextElectionDate" class="cfa-pageHeader-nextElection">Next Election: {{vm.nextElectionDate}}</p>

--- a/app/components/common/pageHeader/pageHeader.html
+++ b/app/components/common/pageHeader/pageHeader.html
@@ -1,3 +1,3 @@
-<h1 class="cfa-pageHeader-title">{{vm.pageTitle}}</h1>
-<h2 ng-if="vm.pageSubtitle" class="cfa-pageHeader-subtitle">{{vm.pageSubtitle}}</h2>
-<p ng-if="vm.nextElectionDate" class="cfa-pageHeader-nextElection">Next Election: {{vm.nextElectionDate}}</p>
+<h1 class="odca-pageHeader-title">{{vm.pageTitle}}</h1>
+<h2 ng-if="vm.pageSubtitle" class="odca-pageHeader-subtitle">{{vm.pageSubtitle}}</h2>
+<p ng-if="vm.nextElectionDate" class="odca-pageHeader-nextElection">Next Election: {{vm.nextElectionDate}}</p>

--- a/app/components/common/pageHeader/pageHeader.less
+++ b/app/components/common/pageHeader/pageHeader.less
@@ -1,8 +1,8 @@
-.cfa-pageHeader {
+.odca-pageHeader {
 	font-family: @headings-font-family;
 }
 
-.cfa-pageHeader-title {
+.odca-pageHeader-title {
 	color: @core-grey-1;
 	font-size: 2.4em;
 	margin-top: 0;
@@ -10,13 +10,13 @@
 	text-transform: capitalize;
 }
 
-.cfa-pageHeader-subtitle {
+.odca-pageHeader-subtitle {
 	font-size: 1.4em;
 	color: @core-grey-3;
 	margin-top: 5px;
 }
 
-.cfa-pageHeader-nextElection {
+.odca-pageHeader-nextElection {
 	.homepageText-subheader;
 	color: @core-grey-2;
 }

--- a/app/components/common/pageHeader/pageHeaderDirective.js
+++ b/app/components/common/pageHeader/pageHeaderDirective.js
@@ -21,19 +21,9 @@
 
     function link(scope, element, attrs, vm) {
       element.addClass('cfa-pageHeader');
-      
-      var htmlItems = element.children();
-      function removeItem(item, index) {
-        if (!item) {
-          htmlItems.eq(index).remove();
-        }
-      }
-
-      removeItem(vm.pageTitle, 0);
-      removeItem(vm.pageSubtitle, 1);
-      removeItem(vm.nextElectionDate, 2);
 
     //  TODO: add function to format election date properly
+
     }
   };
 })();

--- a/app/components/common/pageHeader/pageHeaderDirective.js
+++ b/app/components/common/pageHeader/pageHeaderDirective.js
@@ -20,7 +20,7 @@
     return directive;
 
     function link(scope, element, attrs, vm) {
-      element.addClass('cfa-pageHeader');
+      element.addClass('odca-pageHeader');
 
     //  TODO: add function to format election date properly
 


### PR DESCRIPTION
### Updates

- Same as in #130, I replaced the function in the link method for the pageHeader component that was used to remove unused html elements, with an ng-if inline in the html (previously this had caused problems with the styles, but this was a while back, and it looks like a minor update in Angular somewhere may have fixed this...).
- Replaced the `cfa-` tag in the pageHeader classes to `odca-`
