### PR TITLE
Issue #107 - Adds a text blurb component

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -20,6 +20,7 @@ body .main {
 @import "components/common/blankGraph/blankGraph";
 @import "components/common/linkList/linkList";
 @import "components/common/contributionsCategoryTable/contributionsCategoryTable";
+@import "components/common/textBlurb/textBlurb";
 
 @import "components/homePageModule/homePage";
 @import "components/appMainModule/aboutPageModule/aboutPage";

--- a/app/components/common/measureListing/index.js
+++ b/app/components/common/measureListing/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../textBlurb');
+require('../textBlurb/textBlurb');
 
 var measureListing = angular.module('measureListing', ['textBlurbModule'])
   .directive('measureListing', require('./measureListingDirective'));

--- a/app/components/common/measureListing/index.js
+++ b/app/components/common/measureListing/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var measureListing = angular.module('measureListing', [])
+require('../textBlurb');
+
+var measureListing = angular.module('measureListing', ['textBlurbModule'])
   .directive('measureListing', require('./measureListingDirective'));
 
 module.exports = measureListing;

--- a/app/components/common/measureListing/measureListing.html
+++ b/app/components/common/measureListing/measureListing.html
@@ -1,8 +1,7 @@
 <h3>Measure {{ measure.number }}</h3>
 <div class="subtitle">{{ measure.title }}</div>
 <div class="divided-section">
-  <h4>Full Ballot Text</h4>
-  <p>{{ measure.full_text }}</p>
+  <text-blurb title="Full Ballot Text" body="{{measure.full_text}}"></text-blurb>
 </div>
 <div class="divided-section">
   <h4>Money Supporting the Measure</h4>
@@ -13,6 +12,6 @@
 <div class="divided-section">
   <h4>Money Opposing the Measure</h4>
   <div>
-    <span><a ui-sref="appMain.measure.opposing">{{measure.opposing_count }} opposing committee(s)</a></span>
+    <span><a ui-sref="appMain.measure.opposing">{{ measure.opposing_count }} opposing committee(s)</a></span>
   </div>
 </div>

--- a/app/components/common/textBlurb/index.js
+++ b/app/components/common/textBlurb/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var textBlurb = angular.module('textBlurbModule', ['ui.bootstrap'])
+  .directive('textBlurb', require('./textBlurbDirective.js'));
+
+module.exports = textBlurb;

--- a/app/components/common/textBlurb/textBlurb.html
+++ b/app/components/common/textBlurb/textBlurb.html
@@ -3,8 +3,8 @@
     <div class="text-blurb_body_container" ng-class="{collapsed: textBlurb.isCollapsed}">
         <div class="text-blurb_body">{{textBlurb.body}}</div>
         <!-- Keeping this lorem ipsum text here for testing until we get measure text -->
-<!--         <div class="text-blurb_body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras rhoncus aliquet mauris. Suspendisse ultrices posuere augue, sit amet laoreet urna consectetur eu. Curabitur nulla est, tristique quis dictum vitae, vestibulum posuere nulla. Nam sit amet risus velit. Donec molestie commodo ornare. Vivamus efficitur mattis augue, quis viverra lorem tincidunt sit amet. Vestibulum eleifend ultricies dignissim. Nullam luctus ante justo, eget pretium risus eleifend at. Pellentesque faucibus odio ac massa pharetra varius. Nulla sit amet sem eu nibh scelerisque mollis. Etiam nulla leo, efficitur eu odio ut, bibendum porta tellus.</div>
- -->    </div>
+        <!-- <div class="text-blurb_body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras rhoncus aliquet mauris. Suspendisse ultrices posuere augue, sit amet laoreet urna consectetur eu. Curabitur nulla est, tristique quis dictum vitae, vestibulum posuere nulla. Nam sit amet risus velit. Donec molestie commodo ornare. Vivamus efficitur mattis augue, quis viverra lorem tincidunt sit amet. Vestibulum eleifend ultricies dignissim. Nullam luctus ante justo, eget pretium risus eleifend at. Pellentesque faucibus odio ac massa pharetra varius. Nulla sit amet sem eu nibh scelerisque mollis. Etiam nulla leo, efficitur eu odio ut, bibendum porta tellus.</div> -->
+    </div>
     <div class="text-blurb_action-row">
         <a href="" class="pull-right" ng-click="textBlurb.isCollapsed = false" ng-if="textBlurb.isCollapsed && textBlurb.showButtons">
             Read More <span class="fa fa-chevron-right"></span>

--- a/app/components/common/textBlurb/textBlurb.html
+++ b/app/components/common/textBlurb/textBlurb.html
@@ -1,0 +1,16 @@
+<div class="text-blurb clearfix">
+    <h4 class="text-blurb_title">{{textBlurb.title}}</h4>
+    <div class="text-blurb_body_container" ng-class="{collapsed: textBlurb.isCollapsed}">
+        <div class="text-blurb_body">{{textBlurb.body}}</div>
+        <!-- Keeping this lorem ipsum text here for testing until we get measure text -->
+<!--         <div class="text-blurb_body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras rhoncus aliquet mauris. Suspendisse ultrices posuere augue, sit amet laoreet urna consectetur eu. Curabitur nulla est, tristique quis dictum vitae, vestibulum posuere nulla. Nam sit amet risus velit. Donec molestie commodo ornare. Vivamus efficitur mattis augue, quis viverra lorem tincidunt sit amet. Vestibulum eleifend ultricies dignissim. Nullam luctus ante justo, eget pretium risus eleifend at. Pellentesque faucibus odio ac massa pharetra varius. Nulla sit amet sem eu nibh scelerisque mollis. Etiam nulla leo, efficitur eu odio ut, bibendum porta tellus.</div>
+ -->    </div>
+    <div class="text-blurb_action-row">
+        <a href="" class="pull-right" ng-click="textBlurb.isCollapsed = false" ng-if="textBlurb.isCollapsed && textBlurb.showButtons">
+            Read More <span class="fa fa-chevron-right"></span>
+        </a>
+        <a href="" class="pull-right" ng-click="textBlurb.isCollapsed = true" ng-if="!textBlurb.isCollapsed && textBlurb.showButtons">
+            Hide <span class="fa fa-chevron-up"></span>
+        </a>        
+    </div>
+</div>

--- a/app/components/common/textBlurb/textBlurb.js
+++ b/app/components/common/textBlurb/textBlurb.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var textBlurb = angular.module('textBlurbModule', ['ui.bootstrap'])
+var textBlurb = angular.module('textBlurbModule', [])
   .directive('textBlurb', require('./textBlurbDirective.js'));
 
 module.exports = textBlurb;

--- a/app/components/common/textBlurb/textBlurb.less
+++ b/app/components/common/textBlurb/textBlurb.less
@@ -1,27 +1,27 @@
-.text-blurb {
-    .text-blurb_title {
-        color: @titleTextColor;
-    }
 
-    .text-blurb_body {
-        color: @bodyTextColor;
-    }
-
-    .text-blurb_body_container.collapsed-remove,
-    .text-blurb_body_container {
-        max-height: 5000px; //arbitrarily large number. Cannot be auto for transition to work
-        overflow: hidden;
-        transition: max-height 200ms ease-out;
-    }
-
-    .text-blurb_body_container.collapsed-add,
-    .text-blurb_body_container.collapsed {
-        //TODO: extract lineheight into a variable and multiply here
-        max-height: 80px; //4x line height
-    }
-
-    .text-blurb_action-row {
-        margin-top: 12.5px;
-        margin-bottom: 12.5px;
-    }
+.text-blurb_title {
+    color: @titleTextColor;
 }
+
+.text-blurb_body {
+    color: @bodyTextColor;
+}
+
+.text-blurb_body_container.collapsed-remove,
+.text-blurb_body_container {
+    max-height: 5000px; //arbitrarily large number. Cannot be auto for transition to work
+    overflow: hidden;
+    transition: max-height 200ms ease-out;
+}
+
+.text-blurb_body_container.collapsed-add,
+.text-blurb_body_container.collapsed {
+    //TODO: extract lineheight into a variable and multiply here
+    max-height: 80px; //4x line height
+}
+
+.text-blurb_action-row {
+    margin-top: 12.5px;
+    margin-bottom: 12.5px;
+}
+

--- a/app/components/common/textBlurb/textBlurb.less
+++ b/app/components/common/textBlurb/textBlurb.less
@@ -1,0 +1,27 @@
+.text-blurb {
+    .text-blurb_title {
+        color: @titleTextColor;
+    }
+
+    .text-blurb_body {
+        color: @bodyTextColor;
+    }
+
+    .text-blurb_body_container.collapsed-remove,
+    .text-blurb_body_container {
+        max-height: 5000px; //arbitrarily large number. Cannot be auto for transition to work
+        overflow: hidden;
+        transition: max-height 200ms ease-out;
+    }
+
+    .text-blurb_body_container.collapsed-add,
+    .text-blurb_body_container.collapsed {
+        //TODO: extract lineheight into a variable and multiply here
+        max-height: 80px; //4x line height
+    }
+
+    .text-blurb_action-row {
+        margin-top: 12.5px;
+        margin-bottom: 12.5px;
+    }
+}

--- a/app/components/common/textBlurb/textBlurbDirective.js
+++ b/app/components/common/textBlurb/textBlurbDirective.js
@@ -1,0 +1,55 @@
+/**
+ * textBlurbDirective.js
+ *
+ * A text box with a heading, and a read more link that expands the box to show the full contents
+ **/
+(function() {
+  'use strict';
+  
+  textBlurbDirective.$inject = ['$window'];
+  function textBlurbDirective($window) {
+    var directive = {
+      restrict: 'E',
+      bindToController: {
+        title: '@',
+        body: '@',
+      },
+      link: link,
+      controller: function() {},
+      controllerAs: 'textBlurb',
+      template: require('./textBlurb.html')
+    };
+
+    return directive;
+
+    //////////////////////////////
+    function link(scope, element, attrs, textBlurb) {
+      textBlurb.isCollapsed = true;
+      
+      scope.$watch(function() {return textBlurb.body; }, refreshButtons);
+      angular.element($window).bind('resize', refreshButtons);
+
+      function refreshButtons() {
+        textBlurb.showButtons = shouldShowButtons();
+        scope.$digest(); //since you're outside of angular, you need this here to update the view 
+      }
+
+      // Determine if the height of the inner box is greater than
+      // the height of the container
+      function shouldShowButtons() {
+        var innerElementHeight, outerElementHeight;
+        if (!textBlurb.isCollapsed) {
+          return true;
+        }
+        outerElementHeight = element.find('div')[1].offsetHeight;
+        innerElementHeight = element.find('div')[2].offsetHeight;
+
+        return outerElementHeight < innerElementHeight;
+      }
+    }
+
+  }
+
+  module.exports = textBlurbDirective;
+
+})();

--- a/app/components/common/textBlurb/textBlurbDirective.js
+++ b/app/components/common/textBlurb/textBlurbDirective.js
@@ -31,7 +31,6 @@
 
       function refreshButtons() {
         textBlurb.showButtons = shouldShowButtons();
-        scope.$digest(); //since you're outside of angular, you need this here to update the view 
       }
 
       // Determine if the height of the inner box is greater than

--- a/app/components/common/textBlurb/textBlurbDirective.spec.js
+++ b/app/components/common/textBlurb/textBlurbDirective.spec.js
@@ -1,0 +1,45 @@
+// /*jshint expr: true*/
+
+// 'use strict';
+
+// describe('measureCommitteeOpposingDirective', function() {
+
+//   var scope, measureCommitteeListEl;
+
+//   beforeEach(angular.mock.module('measureCommitteeList'));
+
+//   beforeEach(function() {
+//     //TODO factory.js
+//     var committees = [
+//       {
+//         name: 'American Test Committee',
+//         contributions: 10
+//       },
+//       {
+//         name: 'American Test Commission',
+//         contributions: 10
+//       },
+//       {
+//         name: 'Committee for American Tests',
+//         contributions: 10
+//       }
+//     ];
+
+//     angular.mock.inject(function($compile, $rootScope) {
+//       scope = $rootScope.$new();
+//       scope.committees = committees;
+
+//       measureCommitteeListEl = angular.element('<measure-committee-list committees="committees"></measure-committee-list>');
+//       $compile(measureCommitteeListEl)(scope);
+//       $rootScope.$digest();
+//     });
+//   });
+
+//   afterEach(function() {
+//     measureCommitteeListEl.remove();
+//   });
+
+//   it('should have two committees', function() {
+//     expect(measureCommitteeListEl.find('li')).to.have.length(3);
+//   });
+// });


### PR DESCRIPTION
Adds a simple text-blurb component. For now, only used on the measure listing page, but it's ready to be dropped in where ever we need it.

Resolves issue #107 .

Looks like this:
![screen shot 2016-08-10 at 8 16 00 am](https://cloud.githubusercontent.com/assets/4153920/17559465/3307c4b4-5ed3-11e6-8ace-d4c1c5435151.png)
