### PR TITLE
Update upcoming election views for fixed backend serialization

### DIFF
--- a/app/components/appMainModule/localePageModule/localePageFactory.js
+++ b/app/components/appMainModule/localePageModule/localePageFactory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var localePageFactory = function($log, $http, $q, CONSTANTS) {
+var localePageFactory = function($log, $http, $q, CONSTANTS, disclosureApi) {
   var apiBasePath = CONSTANTS.DISCLOSURE_API_BASEURL;
   var apiEndpoint = '/locality';
 
@@ -34,10 +34,7 @@ var localePageFactory = function($log, $http, $q, CONSTANTS) {
 
   // function getCurrentBallotData() {
   function getCurrentBallotData(localeId) {
-    // return $http.get(apiBasePath + apiEndpoint + '/' + localePageData.metaData.localeId)
-    return $http.get(apiBasePath + apiEndpoint + '/' + localeId + '/current_ballot')
-      .then(getDataComplete)
-      .catch(getMetaDataFailed);
+    return disclosureApi.locality.current_ballot({locality_id: localeId});
   }
 
   // function getDataComplete(data, status, headers, config) {
@@ -57,5 +54,5 @@ var localePageFactory = function($log, $http, $q, CONSTANTS) {
 
 };
 
-localePageFactory.$inject = ['$log', '$http', '$q', 'CONSTANTS'];
+localePageFactory.$inject = ['$log', '$http', '$q', 'CONSTANTS', 'disclosureApi'];
 module.exports = localePageFactory;

--- a/app/components/appMainModule/localePageModule/upcomingElectionsList/UpcomingElectionsListController.js
+++ b/app/components/appMainModule/localePageModule/upcomingElectionsList/UpcomingElectionsListController.js
@@ -40,8 +40,8 @@
       var ballotListItem = {};
       ballotListItem.id = contestObject.id;
       ballotListItem.type = contestObject.contest_type.toLowerCase();
-      ballotListItem.linkTitle = contestObject.name;
-      ballotListItem.linkUrl = $filter('slugify')(contestObject.name);
+      ballotListItem.linkTitle = ballotListItem.type == 'office' ? contestObject.name : 'Measure: ' + contestObject.number + ' ' + contestObject.title;
+      ballotListItem.linkUrl = $filter('slugify')(ballotListItem.linkTitle);
       ballotListItem.electionDate = rawBallotData.date;
       return ballotListItem;
     }

--- a/app/components/appMainModule/localePageModule/upcomingElectionsList/upcomingElectionsListFactory.js
+++ b/app/components/appMainModule/localePageModule/upcomingElectionsList/upcomingElectionsListFactory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function upcomingElectionsListFactory($http, $q, $log, CONSTANTS) {
+function upcomingElectionsListFactory($http, $q, $log, CONSTANTS, disclosureApi) {
   var apiBaseUrl = CONSTANTS.DISCLOSURE_API_BASEURL;
 
   var service = {
@@ -11,9 +11,7 @@ function upcomingElectionsListFactory($http, $q, $log, CONSTANTS) {
   return service;
 
   function getUpcomingElectionData(localeId) {
-    return $http.get(apiBaseUrl + '/locality/' + localeId + '/current_ballot')
-        .then(getUpcomingElectionDataComplete)
-        .catch(getUpcomingElectionDataFailed);
+    return disclosureApi.locality.current_ballot({locality_id: localeId});
   }
 
   function getUpcomingElectionDataComplete(data) {
@@ -25,5 +23,5 @@ function upcomingElectionsListFactory($http, $q, $log, CONSTANTS) {
   }
 }
 
-upcomingElectionsListFactory.$inject = ['$http', '$q', '$log', 'CONSTANTS'];
+upcomingElectionsListFactory.$inject = ['$http', '$q', '$log', 'CONSTANTS', 'disclosureApi'];
 module.exports = upcomingElectionsListFactory;

--- a/app/components/services/disclosure/index.spec.js
+++ b/app/components/services/disclosure/index.spec.js
@@ -13,13 +13,20 @@ describe('disclosureApi', function() {
     disclosureApi = _disclosureApi_;
   }));
 
+  it('errors when the proxy is mismatched with the swagger spec', function(done) {
+    disclosureApi._proxy('foo', 'get')
+      .catch(function(err) {
+        expect(err).to.be.an.error;
+        done();
+      });
+  });
 
   // locality.search
   it('get a locality', function() {
     // Search for any locality
-    disclosureApi.locality.search({q: ''})
+    return disclosureApi.locality.search({q: ''})
       .then(function(localities) {
-        localities.each(function(locality) {
+        localities.forEach(function(locality) {
           expect(locality).to.have.property('name');
           expect(locality).to.have.property('type');
           expect(locality).to.have.property('id');
@@ -30,7 +37,7 @@ describe('disclosureApi', function() {
   // locality.current_ballot
   it('get a ballot', function() {
     // Search for any locality
-    disclosureApi.locality.search({q: ''})
+    return disclosureApi.locality.search({q: ''})
       .then(function(localities) {
         // Get the current ballot for the first locality
         var locality = localities[0];
@@ -44,9 +51,10 @@ describe('disclosureApi', function() {
   });
 
   // office_election.get
-  it('get an office election', function() {
+  // TODO This should be fixed when https://github.com/caciviclab/disclosure-backend/pull/272 is merged
+  it.skip('get an office election', function() {
     // Search for any locality
-    disclosureApi.locality.search({q: ''})
+    return disclosureApi.locality.search({q: ''})
       .then(function(localities) {
         // Get the current ballot for the first locality
         var locality = localities[0];
@@ -62,9 +70,10 @@ describe('disclosureApi', function() {
   });
 
   // candidate.get
-  it('get a candidate', function() {
+  // TODO This should be fixed when https://github.com/caciviclab/disclosure-backend/pull/272 is merged
+  it.skip('get a candidate', function() {
     // Search for any locality
-    disclosureApi.locality.search({q: ''})
+    return disclosureApi.locality.search({q: ''})
       .then(function(localities) {
         // Get the current ballot for the first locality
         var locality = localities[0];

--- a/app/components/services/disclosure/index.spec.js
+++ b/app/components/services/disclosure/index.spec.js
@@ -51,8 +51,7 @@ describe('disclosureApi', function() {
   });
 
   // office_election.get
-  // TODO This should be fixed when https://github.com/caciviclab/disclosure-backend/pull/272 is merged
-  it.skip('get an office election', function() {
+  it('get an office election', function() {
     // Search for any locality
     return disclosureApi.locality.search({q: ''})
       .then(function(localities) {
@@ -70,8 +69,7 @@ describe('disclosureApi', function() {
   });
 
   // candidate.get
-  // TODO This should be fixed when https://github.com/caciviclab/disclosure-backend/pull/272 is merged
-  it.skip('get a candidate', function() {
+  it('get a candidate', function() {
     // Search for any locality
     return disclosureApi.locality.search({q: ''})
       .then(function(localities) {

--- a/app/components/services/disclosure/service.js
+++ b/app/components/services/disclosure/service.js
@@ -85,9 +85,11 @@ DisclosureService.prototype = {
     var swagger = this.swagger;
     var $q = this.$q;
     var $rootScope = this.$rootScope;
+
     // Swagger builds async, unfortunately
     return this.ready.then(function() {
-        return $q(function(resolve, reject) {
+      return $q(function(resolve, reject) {
+        try {
           swagger[namespace][method].call(swagger, params, options,
             function(resp) {
               $rootScope.$apply(function() {
@@ -99,8 +101,11 @@ DisclosureService.prototype = {
                 reject(err);
               });
             });
-        });
+        } catch (err) {
+          reject(err);
+        }
       });
+    });
   }
 };
 


### PR DESCRIPTION
The [backend has fixed](https://github.com/caciviclab/disclosure-backend/pull/272) the ballot serialization, so the frontend needs to change a bit since these are breaking changes.

- Use `name` for office contests, `number` and `title` for referendums (backend is still missing referendum data, so we still get `null`s).
- Added test for disclosure api around error handling when calling a method that doesn't exist in the swagger spec.
- Use the disclosureApi service so I can develop against a local backend.

This should be merged at the same time as https://github.com/caciviclab/disclosure-backend/pull/272