### PR TITLE
Update API base URL to be a static build of our API

### DIFF
--- a/app/appConstants.js
+++ b/app/appConstants.js
@@ -3,8 +3,7 @@
 
 var CONSTANTS = (function() {
     return {
-        // DISCLOSURE_API_BASEURL: 'http://admin.caciviclab.org/docs/api-docs',
-        DISCLOSURE_API_BASEURL: 'http://admin.caciviclab.org:80'
+        DISCLOSURE_API_BASEURL: 'http://disclosure-backend-static.f.tdooner.com'
     };
 }());
 

--- a/app/components/services/settings/index.js
+++ b/app/components/services/settings/index.js
@@ -14,7 +14,7 @@ angular.module('appMain.settings', [])
     // These values come from envify and are injected at build time
     var settings = {
       env: env,
-      DISCLOSURE_SWAGGER_SPEC: process.env.DISCLOSURE_SWAGGER_SPEC || 'http://admin.caciviclab.org/docs/api-docs/'
+      DISCLOSURE_SWAGGER_SPEC: process.env.DISCLOSURE_SWAGGER_SPEC || 'http://disclosure-backend-static.f.tdooner.com/docs/api-docs/'
     };
 
     return settings;


### PR DESCRIPTION
This is a pretty dramatic change, so I suppose we can discuss it at OO
this week. But I have been dreading working on the API roughly ever
since we decided to write it in Python.

Lest I sound like too much a whiner, let me first say that there are
some nice things about django / django-rest-framework that I like, and
are worth me familiarizing myself with:

* The auto-generated API specification (swagger) is awesome for
  communication and easily introspecting API responses.
* Django allows us a well-defined project structure and good tooling
  (tests, deployment, database migrations, etc.)

However, there are many drawbacks to our current implementation of
`disclosure-backend`:

* It is slow. It takes hours to download the data, and many minutes to
  import it all. This makes it especially difficult to iterate quickly
  on import logic changes.
* It has a complicated model hierarchy that uses multiple inheritance
  to mix-in functionality. This creates an inscrutable database schema
  that requires N joins for a model with N subclasses.

  This architecture is largely a vestige of when we were intending to
  support the entire state. I still think this is a good goal, but I
  don't want "perfect to be the enemy of the good" by overengineering
  and failing to deliver Oakland a working site.
* It uses other complex django features, which result in novices like
  myself spending hours debugging instead of writing useful code. To
  name a few things I have spent multiple hours debugging: migration
  behavior on the non-"default" `opendisclosure` database, and trying to
  get tests working for OfficeElection/Referendum fixtures.

As such, I think I can get us to a working product with a simpler
architecture. There is a new repository,
https://github.com/tdooner/disclosure-backend-static, which is
responsible for an offline ETL of the Netfile data for Oakland. The ETL
process's inputs are twofold: 1) Netfile data, 2) Our spreadsheet of
candidates and ballot measures for Oakland. It outputs the entirety of
the API as `.json` files in a folder structure that mimics our existing
API structure.

This means that no frontend code changes (beyond this commit) are
necessary in order for this to work.

This is long enough now, but hopefully will be a good starting point for
discussion. I tested it locally and it seems to work okay. There is a
bit more to read in the README of the new repository.

After submitting this PR, I will be working on beginning to calculate
the metrics we need for our UI.