### PR TITLE
Add office and referendum pages

### DIFF
--- a/app/components/appMainModule/localePageModule/electionTypePage/ElectionTypePageController.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/ElectionTypePageController.js
@@ -10,15 +10,19 @@
 (function() {
   'use strict';
 
-  function ElectionTypePageController($log, $state, $stateParams) {
+  function ElectionTypePageController($log, $state, $stateParams, upcomingElectionsListFactory) {
+    var selectedItem = upcomingElectionsListFactory.getSelectedItemData();
 
     var election = this;
     election.state = $state;
     election.electionType = $stateParams.electionType;
+    election.electionTypeId = $stateParams.electionTypeId || selectedItem.id;
     election.electionTitle = $stateParams.electionTitle;
+
+    election.electionData = selectedItem;
 
   }
 
-  ElectionTypePageController.$inject = ['$log', '$state', '$stateParams'];
+  ElectionTypePageController.$inject = ['$log', '$state', '$stateParams', 'upcomingElectionsListFactory'];
   module.exports = ElectionTypePageController;
 })();

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
@@ -1,10 +1,14 @@
-<div>ELECTION TYPE = {{election.electionType}}</div>
+<!--<div>ELECTION TYPE = {{election.electionType}}</div>-->
 
 <div ng-show="election.electionType == 'office'">OFFICE PAGE</div>
 
 <!--<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div>-->
-<referendum-page referendum-id="{{election.electionTypeId}}" ng-show="election.electionType == 'referendum'"></referendum-page>
+<referendum-page
+  ng-show="election.electionType == 'referendum'"
+  referendum-id="{{election.electionTypeId}}"
+  referendum-data="election.electionData">
+</referendum-page>
 
-<br>
+<!--<br>-->
 
-<pre>{{election.electionData | json}}</pre>
+<!--<pre>{{election.electionData | json}}</pre>-->

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
@@ -1,3 +1,5 @@
 <div>ELECTION TYPE = {{election.electionType}}</div>
 <div ng-show="election.electionType == 'office'">OFFICE PAGE</div>
-<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div>
+<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div><pre>{{election.electionData | json}}</pre><br>
+
+<pre>{{election.electionData | json}}</pre>

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
@@ -1,14 +1,14 @@
 <!--<div>ELECTION TYPE = {{election.electionType}}</div>-->
 
 <office-page
-  ng-show="election.electionType == 'office'"
+  ng-if="election.electionType == 'office'"
   office-id="{{election.electionTypeId}}"
   office-data="election.electionData">
 </office-page>
 
 <!--<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div>-->
 <referendum-page
-  ng-show="election.electionType == 'referendum'"
+  ng-if="election.electionType == 'referendum'"
   referendum-id="{{election.electionTypeId}}"
   referendum-data="election.electionData">
 </referendum-page>

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
@@ -1,6 +1,10 @@
 <!--<div>ELECTION TYPE = {{election.electionType}}</div>-->
 
-<div ng-show="election.electionType == 'office'">OFFICE PAGE</div>
+<office-page
+  ng-show="election.electionType == 'office'"
+  office-id="{{election.electionTypeId}}"
+  office-data="election.electionData">
+</office-page>
 
 <!--<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div>-->
 <referendum-page

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.html
@@ -1,5 +1,10 @@
 <div>ELECTION TYPE = {{election.electionType}}</div>
+
 <div ng-show="election.electionType == 'office'">OFFICE PAGE</div>
-<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div><pre>{{election.electionData | json}}</pre><br>
+
+<!--<div ng-show="election.electionType == 'referendum'">REFERENDUM PAGE</div>-->
+<referendum-page referendum-id="{{election.electionTypeId}}" ng-show="election.electionType == 'referendum'"></referendum-page>
+
+<br>
 
 <pre>{{election.electionData | json}}</pre>

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.js
@@ -1,14 +1,22 @@
 (function() {
   'use strict';
 
-  /* Common Modules 'electionTypePage' Depend on */
+  /* Common Modules 'electionTypePage' Depends on */
   var coreModules = require('../../../common/core/core');
 
+  /* 'electionTypePage' Module Dependencies */
+  var referendumPageModule = require('./referendumPageModule/referendumPage');
+
+  /* Components of 'electionTypePage' */
   var electionTypePageRoutes = require('./electionTypePageRoutes');
   var electionTypePageDirective = require('./electionTypePageDirective');
   var ElectionTypePageController = require('./ElectionTypePageController');
 
-  module.exports = angular.module('electionTypePage', ['coreModules'])
+  module.exports = angular.module('electionTypePage',
+    [
+      'coreModules',
+      'referendumPageModule'
+    ])
     .config(electionTypePageRoutes)
     .directive('localeElectionPage', electionTypePageDirective)
     .controller('ElectionTypePageController', ElectionTypePageController);

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePage.js
@@ -5,6 +5,7 @@
   var coreModules = require('../../../common/core/core');
 
   /* 'electionTypePage' Module Dependencies */
+  var officePageModule = require('./officePageModule/officePage');
   var referendumPageModule = require('./referendumPageModule/referendumPage');
 
   /* Components of 'electionTypePage' */
@@ -15,6 +16,7 @@
   module.exports = angular.module('electionTypePage',
     [
       'coreModules',
+      'officePageModule',
       'referendumPageModule'
     ])
     .config(electionTypePageRoutes)

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePageDirective.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePageDirective.js
@@ -8,7 +8,8 @@
       scope: {},
       controllerAs: 'election',
       bindToController: {
-        electionType: '@type'
+        electionType: '@type',
+        electionTypeId: '@typeId'  //either referendum or office id
       },
       link: link,
       template: template,

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePageRoutes.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePageRoutes.js
@@ -4,12 +4,13 @@ function electionTypePageRoutes($stateProvider) {
 
   var electionTypePage = {
     name: 'appMain.localePage.electionTypePage',
-    url: '/:electionYear/:electionType/:electionTitle',
+    url: '/:electionYear/:electionType/:electionTypeId/:electionTitle',
     // url: '/:electionYear/:electionType',
-    template: '<locale-election-page type="{{ctrl.electionType}}"></locale-election-page>',
+    template: '<locale-election-page type-id="{{ctrl.electionTypeId}}" type="{{ctrl.electionType}}"></locale-election-page>',
     controller: function($scope, $stateParams) {
       var ctrl = this;
       ctrl.electionType = $stateParams.electionType;
+      ctrl.electionTypeId = $stateParams.electionTypeId;
       ctrl.electionTitle = $stateParams.electionTitle;
     },
     controllerAs: 'ctrl'

--- a/app/components/appMainModule/localePageModule/electionTypePage/electionTypePageRoutes.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/electionTypePageRoutes.js
@@ -13,11 +13,11 @@ function electionTypePageRoutes($stateProvider) {
       ctrl.electionTypeId = $stateParams.electionTypeId;
       ctrl.electionTitle = $stateParams.electionTitle;
     },
-    controllerAs: 'ctrl'
-    // ncyBreadcrumb: {
-    //   label: '{{ctrl.electionTitle}}',
-    //   parent: 'appMain.localePage'
-    // }
+    controllerAs: 'ctrl',
+    ncyBreadcrumb: {
+      label: '{{ctrl.electionTitle}}',
+      parent: 'appMain.localePage'
+    }
   };
 
   var officeElectionPage = {

--- a/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/OfficePageController.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/OfficePageController.js
@@ -1,0 +1,60 @@
+'use strict';
+
+/**
+ * @ngdoc controller
+ * @name officePageModule:OfficePageController
+ *
+ * @description
+ *
+ *
+ * @requires $log, $state, officePageFactory
+ * */
+
+function OfficePageController($log, $state, officePageFactory) {
+  // var uiRouterParams = localeStateDataStore.getStateData();
+  // var officePageData = officePageFactory.getOfficePageData();
+  var officePageData = {};
+
+  var office = this;
+  office.state = $state;
+  office.officeTypeId = $state.params.electionTypeId;
+
+  office.candidatesList = [];
+  // office.officeData = officePageData;
+
+  activate();
+  function activate() {
+    return officePageFactory.getListOfCandidatesForOffice(office.officeTypeId)
+      .then(function(data) {
+        officePageData = data;
+        office.pageData = officePageData;
+        $log.info('OFFICE PAGE DATA! = ', officePageData);
+        createCandidatesList(office.pageData.candidates);
+      });
+  }
+
+  function createCandidatesList(candidatesArray) {
+    angular.forEach(candidatesArray, function(candidate) {
+      var candidateListItem = {};
+      candidateListItem = createCandidateListItem(candidate);
+      office.candidatesList.push(candidateListItem);
+    });
+  }
+
+  function createCandidateListItem(candidateObject) {
+    var item = {};
+    item.linkTitle = candidateObject.name;
+    item.subTitle = 'amount collected';
+    item.avatarUrl = candidateObject.photo_url;
+    item.dollarAmount = null;   //TODO: add in total dollar amounts for candidates
+
+    //TODO: add in candidate state for toStateReference!
+    //temporary state so ui-router doesn't throw an error:
+    item.toStateReference = 'appMain.localePage.electionTypePage.officeElection';
+    return item;
+  }
+
+}
+
+OfficePageController.$inject = ['$log', '$state', 'officePageFactory'];
+module.exports = OfficePageController;

--- a/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePage.html
@@ -1,0 +1,9 @@
+<odca-page-header class="officePage-titleText"
+  page-title="{{office.pageData.name}}">
+</odca-page-header>
+
+<odca-link-list list-data="office.candidatesList"></odca-link-list>
+
+<!--<br>-->
+<!--<pre>{{office.officeData | json}}</pre>-->
+<!--<pre>{{office.pageData | json}}</pre>-->

--- a/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePage.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePage.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/* Common Modules 'officePageModule' Depend on */
+var coreModules = require('../../../../common/core/core');
+var pageHeaderModule = require('../../../../common/pageHeader/pageHeader');
+var linkList = require('../../../../common/linkList/linkList');
+
+var officePageDirective = require('./officePageDirective');
+var OfficePageController = require('./OfficePageController');
+var officePageFactory = require('./officePageFactory');
+
+module.exports = angular.module('officePageModule',
+  [
+    'coreModules',
+    'pageHeaderModule',
+    'linkList'
+  ])
+  .directive('officePage', officePageDirective)
+  .controller('OfficePageController', OfficePageController)
+  .factory('officePageFactory', officePageFactory);

--- a/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePageDirective.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePageDirective.js
@@ -1,0 +1,24 @@
+(function() {
+  'use strict';
+
+  var template = require('./officePage.html');
+
+  module.exports = function officePage() {
+    var directive = {
+      restrict: 'E',
+      scope: {},
+      controllerAs: 'office',
+      bindToController: {
+        officeId: '@',
+        officeData: '='
+      },
+      link: link,
+      template: template,
+      controller: 'OfficePageController'
+    };
+    return directive;
+
+    function link(scope, element, attrs, office) {}
+  }
+
+})();

--- a/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePageFactory.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/officePageModule/officePageFactory.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var officePageFactory = function($log, $http, $q, CONSTANTS) {
+  var apiBasePath = CONSTANTS.DISCLOSURE_API_BASEURL;
+  var apiEndpoint = '/office_election';
+
+  var officePageData = {};
+
+  var service = {
+    getListOfCandidatesForOffice: getListOfCandidatesForOffice
+    // getOfficePageData: getOfficePageData
+  };
+  return service;
+
+  function getListOfCandidatesForOffice(officeElectionId) {
+    return $http.get(apiBasePath + apiEndpoint + '/' + officeElectionId)
+      .then(getOfficeDataComplete)
+      // .then(storeOfficeData('metaData', data))
+      .then(function (data) {
+        officePageData = data;
+        $log.info('data from getOfficeMetaData() = ', officePageData);
+        return officePageData;
+      })
+      .catch(getOfficeDataFailed);
+  }
+
+  function getOfficeDataComplete(data) {
+    return data.data;
+  }
+
+  function getOfficeDataFailed(e) {
+    var newMessage = 'XHR Failed for getOfficePageData';
+    if (e.data && e.data.description) {
+      newMessage = newMessage + '\n' + e.data.description;
+    }
+    e.data.description = newMessage;
+    $log.error(newMessage);
+    return $q.reject(e);
+  }
+  
+  // function storeOfficeData(objectTitle, dataObjectToStore) {
+  //   officePageData[objectTitle] = dataObjectToStore;
+  // }
+
+  // function getOfficePageData() {
+  //   return officePageData;
+  // }
+
+};
+
+officePageFactory.$inject = ['$log', '$http', '$q', 'CONSTANTS'];
+module.exports = officePageFactory;

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/ReferendumPageController.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/ReferendumPageController.js
@@ -7,22 +7,28 @@
  * @description
  *
  *
- * @requires $scope
+ * @requires $log, $state, referendumPageFactory
  * */
 
 function ReferendumPageController($log, $state, $stateParams, referendumPageFactory) {
   var metaData = {};
+  // var uiRouterParams = localeStateDataStore.getStateData();
+  var referendumPageData = referendumPageFactory.getReferendumPageData();
 
   var referendum = this;
   referendum.state = $state;
   referendum.referendumTypeId = $state.params.electionTypeId;
+
+  referendum.referendumData = referendumPageData;
+  $log.info('REFERENDUM PAGE DATA = ', referendum.referendumData);
 
   activate();
   function activate() {
     return referendumPageFactory.getReferendumMetaData(referendum.referendumTypeId)
       .then(function(data) {
         metaData = data;
-        referendum.referendumTitle = metaData.title;
+        referendum.metaData = metaData;
+        // referendum.referendumTitle = metaData.title;
         $log.info('REFERENDUM META DATA! = ', metaData);
       });
   }

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/ReferendumPageController.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/ReferendumPageController.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * @ngdoc controller
+ * @name referendumPageModule:ReferendumPageController
+ *
+ * @description
+ *
+ *
+ * @requires $scope
+ * */
+
+function ReferendumPageController($log, $state, $stateParams, referendumPageFactory) {
+  var metaData = {};
+
+  var referendum = this;
+  referendum.state = $state;
+  referendum.referendumTypeId = $state.params.electionTypeId;
+
+  activate();
+  function activate() {
+    return referendumPageFactory.getReferendumMetaData(referendum.referendumTypeId)
+      .then(function(data) {
+        metaData = data;
+        referendum.referendumTitle = metaData.title;
+        $log.info('REFERENDUM META DATA! = ', metaData);
+      });
+  }
+
+}
+
+ReferendumPageController.$inject = ['$log', '$state', '$stateParams', 'referendumPageFactory'];
+module.exports = ReferendumPageController;

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
@@ -1,2 +1,10 @@
-<odca-page-header page-header="{{referendum.referendumTitle}}"></odca-page-header>
-<odca-text-blurb></odca-text-blurb>
+<odca-page-header class="referendumPage-titleText"
+  page-title="Measure {{referendum.metaData.number}}">
+</odca-page-header>
+
+<odca-page-header sub-title="{{referendum.metaData.name}}"></odca-page-header>
+
+<odca-text-blurb title="Abstract" body="{{referendum.metaData.summary}}"></odca-text-blurb>
+
+<br>
+<pre>{{referendum.referendumData | json}}</pre>

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
@@ -1,0 +1,2 @@
+<odca-page-header page-header="{{referendum.referendumTitle}}"></odca-page-header>
+<odca-text-blurb></odca-text-blurb>

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
@@ -6,5 +6,5 @@
 
 <odca-text-blurb title="Abstract" body="{{referendum.metaData.summary}}"></odca-text-blurb>
 
-<br>
-<pre>{{referendum.referendumData | json}}</pre>
+<!--<br>-->
+<!--<pre>{{referendum.referendumData | json}}</pre>-->

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/* Common Modules 'referendumPageModule' Depend on */
+require('../../../../common/core/core');
+var pageHeaderModule = require('../../../../common/pageHeader/pageHeader');
+var textBlurbModule = require('../../../../common/textBlurb/textBlurb');
+
+var referendumPageDirective = require('./referendumPageDirective');
+var ReferendumPageController = require('./ReferendumPageController');
+var referendumPageFactory = require('./referendumPageFactory');
+
+module.exports = angular.module('referendumPageModule',
+  [
+    'coreModules',
+    'pageHeaderModule',
+    'textBlurbModule'
+  ])
+  .directive('referendumPage', referendumPageDirective)
+  .controller('ReferendumPageController', ReferendumPageController)
+  .factory('referendumPageFactory', referendumPageFactory);

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.less
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.less
@@ -1,0 +1,3 @@
+.referendumPage-titleText {
+  font-size: 85%;
+}

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageDirective.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageDirective.js
@@ -1,4 +1,5 @@
 (function() {
+  'use strict';
 
   var template = require('./referendumPage.html');
 
@@ -8,7 +9,8 @@
       scope: {},
       controllerAs: 'referendum',
       bindToController: {
-        referendumId: '@'
+        referendumId: '@',
+        referendumData: '='
       },
       link: link,
       template: template,
@@ -16,7 +18,7 @@
     };
     return directive;
 
-    function link(scope, element, attrs, election) {}
+    function link(scope, element, attrs, referendum) {}
   }
 
 })();

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageDirective.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageDirective.js
@@ -1,0 +1,22 @@
+(function() {
+
+  var template = require('./referendumPage.html');
+
+  module.exports = function referendumPage() {
+    var directive = {
+      restrict: 'E',
+      scope: {},
+      controllerAs: 'referendum',
+      bindToController: {
+        referendumId: '@'
+      },
+      link: link,
+      template: template,
+      controller: 'ReferendumPageController'
+    };
+    return directive;
+
+    function link(scope, element, attrs, election) {}
+  }
+
+})();

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageFactory.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageFactory.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var referendumPageFactory = function($log, $http, $q, CONSTANTS) {
+  var apiBasePath = CONSTANTS.DISCLOSURE_API_BASEURL;
+  var apiEndpoint = '/referendum';
+
+  var referendumPageData = {};
+  referendumPageData.metaData = {};
+
+  var service = {
+    getReferendumMetaData: getReferendumMetaData
+  };
+  return service;
+
+  function getReferendumMetaData(referendumId) {
+    return $http.get(apiBasePath + apiEndpoint + '/' + referendumId)
+      .then(getReferendumDataComplete)
+      // .then(storeReferendumData('metaData', data))
+      .then(function (data) {
+        referendumPageData.metaData = data;
+        $log.info('data from getReferendumMetaData() = ', referendumPageData.metaData);
+        return referendumPageData.metaData;
+      })
+      .catch(getReferendumDataFailed);
+  }
+
+  // function storeReferendumData(objectTitle, dataObjectToStore) {
+  //   referendumPageData[objectTitle] = dataObjectToStore;
+  // }
+  //
+  // function getReferendumPageData() {
+  //   return referendumPageData;
+  // }
+
+  function getReferendumDataComplete(data) {
+    return data.data;
+  }
+
+  function getReferendumDataFailed(e) {
+    var newMessage = 'XHR Failed for getReferendumPageData';
+    if (e.data && e.data.description) {
+      newMessage = newMessage + '\n' + e.data.description;
+    }
+    e.data.description = newMessage;
+    $log.error(newMessage);
+    return $q.reject(e);
+  }
+};
+
+referendumPageFactory.$inject = ['$log', '$http', '$q', 'CONSTANTS'];
+module.exports = referendumPageFactory;

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageFactory.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPageFactory.js
@@ -8,7 +8,8 @@ var referendumPageFactory = function($log, $http, $q, CONSTANTS) {
   referendumPageData.metaData = {};
 
   var service = {
-    getReferendumMetaData: getReferendumMetaData
+    getReferendumMetaData: getReferendumMetaData,
+    getReferendumPageData: getReferendumPageData
   };
   return service;
 
@@ -27,10 +28,10 @@ var referendumPageFactory = function($log, $http, $q, CONSTANTS) {
   // function storeReferendumData(objectTitle, dataObjectToStore) {
   //   referendumPageData[objectTitle] = dataObjectToStore;
   // }
-  //
-  // function getReferendumPageData() {
-  //   return referendumPageData;
-  // }
+
+  function getReferendumPageData() {
+    return referendumPageData;
+  }
 
   function getReferendumDataComplete(data) {
     return data.data;

--- a/app/components/appMainModule/localePageModule/localePage.html
+++ b/app/components/appMainModule/localePageModule/localePage.html
@@ -8,12 +8,12 @@
 
 <div class="container-fluid">
 	<div class="row bg-white">
-		<div class="col-xs-12 col-sm-4 localePage-listContainer">
+		<div class="col-xs-12 col-sm-4 localePage-electionsListContainer">
 			<locale-upcoming-elections-list locale-id="locale.localeId" locale-type="locale.localeType"></locale-upcoming-elections-list>
 		</div>
 		<div class="col-xs-12 col-sm-8">
 			<!--TODO: Fix breadcrumb problem caused by adding this view in-->
-			<div ui-view></div>
+			<div class="localePage-electionTypePageContainer" ui-view></div>
 		</div>
 	</div>
 </div>

--- a/app/components/appMainModule/localePageModule/localePage.less
+++ b/app/components/appMainModule/localePageModule/localePage.less
@@ -1,3 +1,9 @@
-.localePage-listContainer {
+@import "./electionTypePage/referendumPageModule/referendumPage";
+
+.localePage-electionsListContainer {
   border-right: 2px solid @body-bg;
+}
+
+.localePage-electionTypePageContainer {
+  padding: 15px 10px;
 }

--- a/app/components/appMainModule/localePageModule/localePageRoutes.js
+++ b/app/components/appMainModule/localePageModule/localePageRoutes.js
@@ -7,24 +7,28 @@ function localePageRoutes($stateProvider) {
     url: '^/:localeType/:localeId/:localeName',   // The ^ character makes this url override the parent url
     // template: '<{{ctrl.localeType}}-page><' + '/' + '{{ctrl.localeType}}' + '-page>',
     // template: '<div ui-view="{{ctrl.localeType}}"></div>',
-    template: '<locale-page class="page-fade" locale-name="{{ctrl.localeName}}"></locale-page>',
-    controller: function($scope, $stateParams) {
-      var ctrl = this;
-      ctrl.localeName = $stateParams.localeName;
-      ctrl.localeType = $stateParams.localeType;
+    template: '<locale-page class="page-fade" locale-name="{{localeCtrl.localeName}}"></locale-page>',
+    controller: function($scope, $state, $stateParams) {
+      var localeCtrl = this;
+      localeCtrl.localeName = $stateParams.localeName;
+      localeCtrl.localeType = $stateParams.localeType;
+      // this.localeState = $state;
+      // console.log('this.localeState = ', this.localeState);
     },
-    controllerAs: 'ctrl',
+    controllerAs: 'localeCtrl',
     deepStateRedirect: true,
     sticky: true,
     ncyBreadcrumb: {
       // label: 'Locale Page',
-      label: '{{ctrl.localeName}}',
+      label: "'localeCtrl.localeName'",
+      // label: $state.params.localeName,
+      // label: '{{this.localeName}}',
       parent: 'appMain'
     },
     data: {
       moduleClasses: 'page', // assign a module class to the <body> tag
       pageClasses: 'localePage', // assign a page-specific class to the <body> tag
-      pageTitle: '{{ctrl.localeName}}', // set the title in the <head> section of the index.html file
+      pageTitle: '{{localeCtrl.localeName}}', // set the title in the <head> section of the index.html file
       pageDescription: 'Meta Description goes here' // meta description in <head>
     }
   };

--- a/app/components/appMainModule/localePageModule/upcomingElectionsList/UpcomingElectionsListController.js
+++ b/app/components/appMainModule/localePageModule/upcomingElectionsList/UpcomingElectionsListController.js
@@ -4,6 +4,8 @@
   function UpcomingElectionsListController($log, $stateParams, $filter, upcomingElectionsListFactory) {
     var rawBallotData = {};
     var ballotList = {};
+    var selectedItem = upcomingElectionsListFactory.getSelectedItemData();
+
     ballotList.offices = [];
     ballotList.councilPositions = [];
     ballotList.measures = [];
@@ -38,17 +40,21 @@
 
     function createBallotListItem(contestObject) {
       var ballotListItem = {};
-      ballotListItem.id = contestObject.id;
       ballotListItem.type = contestObject.contest_type.toLowerCase();
       ballotListItem.linkTitle = contestObject.name;
       ballotListItem.linkData = {
         // electionYear: $filter('date')(rawBallotData.date, 'yyyy'),
         electionYear: $filter('limitTo')(rawBallotData.date, 4, 0),
         electionType: contestObject.contest_type.toLowerCase(),
+        electionTypeId: contestObject.id,
         electionTitle: $filter('slugify')(contestObject.name)
       };
       ballotListItem.toState = defineStateForBallotItem(ballotListItem.linkData);
       ballotListItem.electionDate = rawBallotData.date;
+      ballotListItem.onItemSelected = function(itemData) {
+        $log.info('ON ITEM SELECTED = ', itemData);
+        upcomingElectionsListFactory.storeSelectedItemData(itemData);
+      };
       return ballotListItem;
     }
 
@@ -65,7 +71,7 @@
 
     function defineStateForBallotItem(linkDataObject) {
       var state;
-      state = 'appMain.localePage.electionTypePage({electionYear: ' + linkDataObject.electionYear + ', electionType: "' + linkDataObject.electionType + '", electionTitle: "' + linkDataObject.electionTitle + '"})';
+      state = 'appMain.localePage.electionTypePage({electionYear: ' + linkDataObject.electionYear + ', electionType: "' + linkDataObject.electionType + '", electionTypeId: "' + linkDataObject.electionTypeId + '", electionTitle: "' + linkDataObject.electionTitle + '"})';
       return state;
     }
 

--- a/app/components/appMainModule/localePageModule/upcomingElectionsList/upcomingElectionsListFactory.js
+++ b/app/components/appMainModule/localePageModule/upcomingElectionsList/upcomingElectionsListFactory.js
@@ -3,10 +3,14 @@
 function upcomingElectionsListFactory($http, $q, $log, CONSTANTS) {
   var apiBaseUrl = CONSTANTS.DISCLOSURE_API_BASEURL;
 
+  var selectedItemData = {};
+
   var service = {
     // getListOfOffices: getListOfOffices
     // getListOfOfficeElections: getListOfOfficeElections,
-    getUpcomingElectionData: getUpcomingElectionData
+    getUpcomingElectionData: getUpcomingElectionData,
+    getSelectedItemData: getSelectedItemData,  //Add here for now. TODO: review
+    storeSelectedItemData: storeSelectedItemData   //Add here for now. TODO: review
   };
   return service;
 
@@ -14,6 +18,22 @@ function upcomingElectionsListFactory($http, $q, $log, CONSTANTS) {
     return $http.get(apiBaseUrl + '/locality/' + localeId + '/current_ballot')
         .then(getUpcomingElectionDataComplete)
         .catch(getUpcomingElectionDataFailed);
+  }
+
+  function getSelectedItemData() {
+    return selectedItemData;
+  }
+
+  //CRUD-like function to store data from selected item
+  function storeSelectedItemData(selectedItem) {
+    selectedItemData = selectedItem;
+    $log.info('SELECTED ITEM DATA = ', selectedItemData)
+  }
+
+  //CRUD-like function to remove any data stored in memory for a selected item
+  function clearSelectedItemData() {
+    selectedItemData = {};
+    $log.log('cleared selected item = ', selectedItemData);
   }
 
   function getUpcomingElectionDataComplete(data) {

--- a/app/components/common/linkList/linkList.html
+++ b/app/components/common/linkList/linkList.html
@@ -2,7 +2,7 @@
 	<h3 ng-if="vm.listTitle" class="odca-linkList-header">{{vm.listTitle}}</h3>
 	<ul class="odca-linkList">
 		<li class="odca-linkListItem" ng-repeat="item in vm.listData" ng-class="{'odca-linkListItem-withListHeader': vm.hasHeader }">
-			<odca-link-list-item to-state="item.toState" link-title="item.linkTitle" sub-title="item.subTitle" dollar-amount="item.dollarAmount | currency:'$':0" avatar-url="item.avatarUrl" ng-class="{'odca-linkListItem-avatar--indented': item.avatarUrl !== undefined || null, 'odca-linkListItem-textContent--indented': item.avatarUrl === undefined || null}"></odca-link-list-item>
+			<odca-link-list-item to-state="item.toState" link-title="item.linkTitle" sub-title="item.subTitle" dollar-amount="item.dollarAmount | currency:'$':0" avatar-url="item.avatarUrl" on-item-selected="item.onItemSelected(item)" ng-class="{'odca-linkListItem-avatar--indented': item.avatarUrl !== undefined || null, 'odca-linkListItem-textContent--indented': item.avatarUrl === undefined || null}"></odca-link-list-item>
 		</li>
 	</ul>
 </div>

--- a/app/components/common/linkList/linkListItem/linkListItem.html
+++ b/app/components/common/linkList/linkListItem/linkListItem.html
@@ -1,6 +1,6 @@
 <article>
 	<!--TODO: CHANGE HREF TO UI-SREF-->
-	<a class="odca-linkListItem-link" ui-sref="{{vm.toStateReference}}">
+	<a class="odca-linkListItem-link" ui-sref="{{vm.toStateReference}}" ng-click="vm.onItemSelected()">
 		<div class="odca-linkListItem-contentContainer">
 			<img class="odca-linkListItem-avatar" ng-if="vm.avatarImageUrl" ng-src="{{vm.avatarImageUrl}}" alt=""/>
 

--- a/app/components/common/linkList/linkListItem/linkListItemDirective.js
+++ b/app/components/common/linkList/linkListItem/linkListItemDirective.js
@@ -21,7 +21,8 @@
         linkSubTitle: '=subTitle',
         toStateReference: '=toState',
         linkDollarAmount: '=dollarAmount',
-        avatarImageUrl: '=avatarUrl'
+        avatarImageUrl: '=avatarUrl',
+        onItemSelected: '&'
       },
       link: link,
       template: template,

--- a/app/components/common/textBlurb/textBlurb.js
+++ b/app/components/common/textBlurb/textBlurb.js
@@ -1,6 +1,6 @@
 'use strict';
 
 var textBlurb = angular.module('textBlurbModule', [])
-  .directive('textBlurb', require('./textBlurbDirective.js'));
+  .directive('odcaTextBlurb', require('./textBlurbDirective.js'));
 
 module.exports = textBlurb;

--- a/app/components/common/textBlurb/textBlurbDirective.js
+++ b/app/components/common/textBlurb/textBlurbDirective.js
@@ -6,13 +6,13 @@
 (function() {
   'use strict';
   
-  textBlurbDirective.$inject = ['$window'];
-  function textBlurbDirective($window) {
+  odcaTextBlurb.$inject = ['$window'];
+  function odcaTextBlurb($window) {
     var directive = {
       restrict: 'E',
       bindToController: {
         title: '@',
-        body: '@',
+        body: '@'
       },
       link: link,
       controller: function() {},
@@ -49,6 +49,6 @@
 
   }
 
-  module.exports = textBlurbDirective;
+  module.exports = odcaTextBlurb;
 
 })();


### PR DESCRIPTION
**Note: this is related to #146 and should be merged after

This is still in progress but I think @KyleW and I may have overlapped in what we're working on and I wanted him to be able to check this out so we can figure out what to do.

So far, this:
- Adds a `Referendum` page (used for measures) and an `Office` page as child components of the `electionTypePage`, since they are similar in data structures but different in layout.
- Incudes linkable routes to the referendum and office pages (related to/fixes (?) #145)
- Presents a working draft version of the updated mocks (v.15/16) from @elinaru
- Includes the `textBlurb` on the `Referendum` page and the list of candidates on the `Office` page, and binds data to these components (closes #108)

TO DO:
- Add supporting and opposing charts to `Referendum` page (related to #112 and #144)
- Get `dollarAmount` for `Office` page
- Finish styling
- Review layout and desktop/mobile functionality with @elinaru and rest of team (although this may be better to do in a separate pull request)
- Review `Office` page functionality / layout with @elinaru and team (also could be done in separate pull request)

@KyleW what are your thoughts? How do you want to proceed?
