### PR TITLE
Fix urls for referendum money pages

### DIFF
--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/ReferendumPageController.js
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/ReferendumPageController.js
@@ -16,7 +16,7 @@ function ReferendumPageController($log, $state, $stateParams, referendumPageFact
   var referendumPageData = referendumPageFactory.getReferendumPageData();
 
   var referendum = this;
-  referendum.state = $state;
+  referendum.state = $stateParams;
   referendum.referendumTypeId = $state.params.electionTypeId;
 
   //TODO move these to resolve

--- a/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
+++ b/app/components/appMainModule/localePageModule/electionTypePage/referendumPageModule/referendumPage.html
@@ -10,7 +10,7 @@
   <h3 class="section-header">Money supporting the measure <span class="section-header__subtext">{{ referendum.supporting.total_contributions | dollar }}</span></h3>
   <money-by-region money="referendum.supporting.contributions_by_region" color="green"></money-by-region>
   <div class="see-more" ng-if="!!referendum.supporting.supporting_organizations.length">
-    <a class="see-more__content" ui-sref="appMain.localePage.referendumMoney({localeType: 'city', localeName: referendum.localeName, localeId: 2, localeName: referendum.localeName, electionYear: 2016, electionType: 'referendum', electionTitle: referendum.electionTitle, electionTypeId: referendum.metaData.id, support_or_oppose: 'supporting'})">{{ referendum.supporting.supporting_organizations.length }} supporting <span class="text-nowrap">committees <span class="fa fa-chevron-right"></span></span></a>
+    <a class="see-more__content" ui-sref="appMain.localePage.referendumMoney(referendum.state)">{{ referendum.supporting.supporting_organizations.length }} supporting <span class="text-nowrap">committees <span class="fa fa-chevron-right"></span></span></a>
   </div>
   <div class="see-more" ng-if="!referendum.supporting.supporting_organizations.length">
     No data on supporting committees
@@ -20,7 +20,7 @@
   <h3 class="section-header">Money opposing the measure <span class="section-header__subtext">{{ referendum.opposing.total_contributions | dollar }}</span></h3>
   <money-by-region money="referendum.opposing.contributions_by_region" color="red"></money-by-region>
   <div class="see-more" ng-if="!!referendum.opposing.opposing_organizations.length">
-    <a class="see-more__content" ui-sref="appMain.localePage.referendumMoney({localeType: 'city', localeName: referendum.localeName, localeId: 2, localeName: referendum.localeName, electionYear: 2016, electionType: 'referendum', electionTitle: referendum.electionTitle, electionTypeId: referendum.metaData.id, support_or_oppose: 'opposing'})">{{ referendum.opposing.opposing_organizations.length }} opposing <span class="text-no-break">committees <span class="fa fa-chevron-right"></span></span></a>
+    <a class="see-more__content" ui-sref="appMain.localePage.referendumMoney(referendum.state)">{{ referendum.opposing.opposing_organizations.length }} opposing <span class="text-no-break">committees <span class="fa fa-chevron-right"></span></span></a>
   </div>
   <div class="see-more" ng-if="!referendum.opposing.opposing_organizations.length">
     No data on opposing committees


### PR DESCRIPTION
Currently seeing urls like http://disclosure.caciviclab.org/#!/city/2//2016/referendum/1//supporting on the [referendum page](http://disclosure.caciviclab.org/#!/city/2/oakland/2016/referendum/1/sugar-sweetened-beveragetax). This makes sure the directive has the state it needs to pass to the `ui-sref`.