### PR TITLE
Bug/percentage rounding

### DIFF
--- a/app/components/common/candidate/candidate_page.html
+++ b/app/components/common/candidate/candidate_page.html
@@ -41,7 +41,7 @@
     <h3>Contributions</h3>
     <div>
       <div class="component__heading" ng-repeat-start="(label, amount) in $ctrl.contributions_by_type_percentages">{{ label }}</div>
-      <odca-money-bar-chart value="{{ amount }}" max="100" format="percentage" color="green" ng-repeat-end></odca-money-bar-chart>
+      <odca-money-bar-chart value="{{ amount }}" max="1000" precision="1" format="percentage" color="green" ng-repeat-end></odca-money-bar-chart>
     </div>
   </div>
   <div ng-if="$ctrl.supporting.total_expenditures" class="divided-section is-off-screen" when-visible="$ctrl.onVisible">

--- a/app/components/common/candidate/candidate_page.html
+++ b/app/components/common/candidate/candidate_page.html
@@ -40,8 +40,8 @@
     <span class="text-serif text-grey-4">Money coming in</span>
     <h3>Contributions</h3>
     <div>
-      <div class="component__heading" ng-repeat-start="(label, amount) in $ctrl.supporting.contributions_by_type">{{ label }}</div>
-      <odca-money-bar-chart value="{{ amount }}" max="{{ $ctrl.supporting.total_contributions }}" format="percentage" color="green" ng-repeat-end></odca-money-bar-chart>
+      <div class="component__heading" ng-repeat-start="(label, amount) in $ctrl.contributions_by_type_percentages">{{ label }}</div>
+      <odca-money-bar-chart value="{{ amount }}" max="100" format="percentage" color="green" ng-repeat-end></odca-money-bar-chart>
     </div>
   </div>
   <div ng-if="$ctrl.supporting.total_expenditures" class="divided-section is-off-screen" when-visible="$ctrl.onVisible">

--- a/app/components/common/candidate/index.js
+++ b/app/components/common/candidate/index.js
@@ -3,9 +3,10 @@
 var angular = require('angular');
 
 angular.module('odca.candidate', [
+  require('../money'),
+  require('../percentageCalculator'),
   require('./photo.filter'),
-  require('../page_metadata'),
-  require('../money')
+  require('../page_metadata')
 ])
   .directive('odcaCandidatePage', function () {
     return {
@@ -40,17 +41,19 @@ function CandidateProfileController () {
 }
 
 
-function CandidatePageController () {
+function CandidatePageController (percentageCalculator) {
   var ctrl = this;
   ctrl.onVisible = onVisible;
 
   ctrl.supporting.$promise.then(function (supporting) {
     ctrl.current_balance = supporting.total_contributions - supporting.total_expenditures + supporting.total_loans_received;
+    ctrl.contributions_by_type_percentages = percentageCalculator(supporting.contributions_by_type);
   });
 
   function onVisible ($el) {
     $el.removeClass('is-off-screen');
   }
 }
+
 
 module.exports = 'odca.candidate';

--- a/app/components/common/candidate/index.js
+++ b/app/components/common/candidate/index.js
@@ -47,7 +47,7 @@ function CandidatePageController (percentageCalculator) {
 
   ctrl.supporting.$promise.then(function (supporting) {
     ctrl.current_balance = supporting.total_contributions - supporting.total_expenditures + supporting.total_loans_received;
-    ctrl.contributions_by_type_percentages = percentageCalculator(supporting.contributions_by_type);
+    ctrl.contributions_by_type_percentages = percentageCalculator(supporting.contributions_by_type, 1000);
   });
 
   function onVisible ($el) {

--- a/app/components/common/money/index.js
+++ b/app/components/common/money/index.js
@@ -36,6 +36,7 @@ angular.module('odca.money', [
         color: '@', // One of green, red, blue
         format: '@', // How to format the value, money or percentage
         max: '@', // The maximum value (what counts as 100%) and is used to scale the measure
+        precision: '@', // How many decimal places to format percentages
         value: '@' // The value to visualize
       }
     };
@@ -84,12 +85,14 @@ function MoneyBarChartController ($filter) {
   }
 
   function displayValue() {
-    return format(ctrl.format, ctrl.value);
+    return format(ctrl.format, ctrl.value, ctrl.max, parseInt(ctrl.precision));
   }
 
-  function format (format, value) {
+  function format (format, value, max, precision) {
+    precision = precision || 0;
+
     if (format === 'percentage') {
-      return $filter('number')(value / ctrl.max * 100, 0) + '%';
+      return $filter('number')(value / max * 100, precision) + '%';
     } else if (format === 'money') {
       return $filter('dollar')(value);
     } else {
@@ -120,7 +123,7 @@ function MoneyByRegionController ($scope, percentageCalculator) {
     });
 
     ctrl.total = total;
-    ctrl.money_by_region_percentages = percentageCalculator(money_by_region, 100);
+    ctrl.money_by_region_percentages = percentageCalculator(money_by_region, 1000);
   });
 
   function onVisible ($el) {

--- a/app/components/common/money/index.js
+++ b/app/components/common/money/index.js
@@ -101,7 +101,7 @@ function MoneyBarChartController ($filter) {
 MoneyBarChartController.$inject = ['$filter'];
 
 
-function MoneyByRegionController ($scope) {
+function MoneyByRegionController ($scope, percentageCalculator) {
   var ctrl = this;
   ctrl.onVisible = onVisible;
   ctrl.total = null;
@@ -112,12 +112,15 @@ function MoneyByRegionController ($scope) {
     }
 
     // Map the money to key, values
-    ctrl.money_by_region = {};
-    ctrl.total = 0;
+    var money_by_region = {};
+    var total = 0;
     angular.forEach(money, function(moneyDescriptor) {
-      ctrl.money_by_region[moneyDescriptor.locale] = moneyDescriptor.amount;
-      ctrl.total += moneyDescriptor.amount;
+      money_by_region[moneyDescriptor.locale] = moneyDescriptor.amount;
+      total += moneyDescriptor.amount;
     });
+
+    ctrl.total = total;
+    ctrl.money_by_region_percentages = percentageCalculator(money_by_region, 100);
   });
 
   function onVisible ($el) {
@@ -125,6 +128,7 @@ function MoneyByRegionController ($scope) {
   }
 }
 
-MoneyByRegionController.$inject = ['$scope'];
+MoneyByRegionController.$inject = ['$scope', 'percentageCalculator'];
+
 
 module.exports = 'odca.money';

--- a/app/components/common/money/money_by_region.html
+++ b/app/components/common/money/money_by_region.html
@@ -1,4 +1,4 @@
 <div class="money-by-region is-off-screen" when-visible="$ctrl.onVisible">
-  <div class="money-by-region__heading" ng-repeat-start="(label, amount) in $ctrl.money_by_region">{{ label }}</div>
-  <odca-money-bar-chart ng-repeat-end value="{{ amount }}" format="percentage" color="{{ $ctrl.color }}" max="100"></odca-money-bar-chart>
+  <div class="money-by-region__heading" ng-repeat-start="(label, amount) in $ctrl.money_by_region_percentages">{{ label }}</div>
+  <odca-money-bar-chart ng-repeat-end value="{{ amount }}" format="percentage" color="{{ $ctrl.color }}" max="1000" precision="1"></odca-money-bar-chart>
 </div>

--- a/app/components/common/money/money_by_region.html
+++ b/app/components/common/money/money_by_region.html
@@ -1,4 +1,4 @@
 <div class="money-by-region is-off-screen" when-visible="$ctrl.onVisible">
   <div class="money-by-region__heading" ng-repeat-start="(label, amount) in $ctrl.money_by_region">{{ label }}</div>
-  <odca-money-bar-chart ng-repeat-end value="{{ amount }}" format="percentage" color="{{ $ctrl.color }}" max="{{ $ctrl.total }}"></odca-money-bar-chart>
+  <odca-money-bar-chart ng-repeat-end value="{{ amount }}" format="percentage" color="{{ $ctrl.color }}" max="100"></odca-money-bar-chart>
 </div>

--- a/app/components/common/percentageCalculator/index.js
+++ b/app/components/common/percentageCalculator/index.js
@@ -1,0 +1,54 @@
+'use strict';
+
+angular.module('odca.percentageCalculator', [])
+  .factory('percentageCalculator', function() {
+    return percentageCalculator;
+
+    // http://stackoverflow.com/a/13483710
+    // Calculate the percentages based on the Largest Remainder Method for the
+    // the collection of key, value pairs, making sure the sum adds to 100% (or
+    // target).
+    function percentageCalculator(moneyCollection, target) {
+      if (!moneyCollection) {
+        return {};
+      }
+
+      target = target || 100;
+      var percentages = {};
+
+      var total = 0;
+      angular.forEach(moneyCollection, function(value) {
+        total += value;
+      });
+
+      // Start with the integer parts
+      var totalPercentage = 0;
+      angular.forEach(moneyCollection, function(value, key) {
+        percentages[key] = Math.floor(value / total * target);
+        totalPercentage += percentages[key];
+      });
+
+      var remainingPercentage = target - totalPercentage;
+      if (!remainingPercentage) {
+        return percentages;
+      }
+
+      // Sort keys by largest decimal part
+      var sortedKeys = Object.keys(moneyCollection);
+      sortedKeys.sort(function(a, b) {
+        return (moneyCollection[b] / total * target % 1) - (moneyCollection[a] / total * target % 1);
+      });
+
+      // Distribute the remaining percentage
+      while (remainingPercentage) {
+        var key = sortedKeys.shift();
+        percentages[key]++;
+        remainingPercentage--;
+      }
+
+      return percentages;
+    }
+  });
+
+
+module.exports = 'odca.percentageCalculator';

--- a/app/components/common/referendum/referendum_money.html
+++ b/app/components/common/referendum/referendum_money.html
@@ -17,7 +17,7 @@
                   <div class="row">
                     <div class="col-xs-8">
                       <div class="committee-list__money-bar-chart">
-                        <odca-money-bar-chart value="{{ committee.amount }}" max="{{ $ctrl.money.total_contributions }}" color="green" format="percentage"></odca-money-bar-chart>
+                        <odca-money-bar-chart value="{{ committee.amount }}" max="{{ $ctrl.money.total_contributions }}" color="green" format="percentage" precision="1"></odca-money-bar-chart>
                       </div>
                     </div>
                     <div class="col-xs-4">


### PR DESCRIPTION
Fixes #163 

Spoke to @elinaru about this, by showing a single decimal place, we reduce the variance in rounding significantly. It also makes some of the contests which have significant spread in numbers  (like [HH](http://www.opendisclosure.io/#!/city/2/oakland/2016/referendum/1/sugar-sweetened-beveragetax)) show up more reasonably. So now "Money Within Oakland" shows 0.1% instead of 0%.

Also uses the Largest Remainder method for assigning percentage points to the numbers, so the sums will always total 100%.

I'm not crazy about the API, thinking about pulling this into it's own directive, but good enough for now I suppose.

cc @KyleW 