### PR TITLE
Add a link to candidate contributions page

### DIFF
--- a/app/components/appMainModule/committeePageModule/committeePage.html
+++ b/app/components/appMainModule/committeePageModule/committeePage.html
@@ -1,5 +1,5 @@
 
-<div class="container">
+<div class="fluid-container">
     <div class="row">
         <div class="col-xs-12">
             <odca-page-header page-title="{{committee.name}}"></odca-page-header>

--- a/app/components/common/candidate/candidate_page.html
+++ b/app/components/common/candidate/candidate_page.html
@@ -39,10 +39,10 @@
       <div class="component__heading" ng-repeat-start="(label, amount) in $ctrl.contributions_by_type_percentages">{{ label }}</div>
       <odca-money-bar-chart value="{{ amount }}" max="1000" precision="1" format="percentage" color="green" ng-repeat-end></odca-money-bar-chart>
     </div>
-    <div class="see-more" ng-if="!!$ctrl.supporting.total_contributions">
-      <a class="see-more__content" ui-sref="appMain.committee.main({filer_id: $ctrl.candidate.filer_id})")"><span class="text-no-break">See all contributions<span class="fa fa-chevron-right"></span></span></a>
+    <div class="see-more" ng-if="$ctrl.supporting.total_contributions > 0">
+      <a class="see-more__content" ui-sref="appMain.committee.main({filer_id: $ctrl.candidate.filer_id})">See all <span class="text-no-break">contributions<span class="fa fa-chevron-right"></span></span></a>
     </div>
-    <div class="see-more" ng-if="!$ctrl.supporting.total_contributions">
+    <div class="see-more" ng-if="!($ctrl.supporting.total_contributions > 0)">
       No data on contributions
     </div>
 

--- a/app/components/common/candidate/candidate_page.html
+++ b/app/components/common/candidate/candidate_page.html
@@ -39,6 +39,13 @@
       <div class="component__heading" ng-repeat-start="(label, amount) in $ctrl.contributions_by_type_percentages">{{ label }}</div>
       <odca-money-bar-chart value="{{ amount }}" max="1000" precision="1" format="percentage" color="green" ng-repeat-end></odca-money-bar-chart>
     </div>
+    <div class="see-more" ng-if="!!$ctrl.supporting.total_contributions">
+      <a class="see-more__content" ui-sref="appMain.committee.main({filer_id: $ctrl.candidate.filer_id})")"><span class="text-no-break">See all contributions<span class="fa fa-chevron-right"></span></span></a>
+    </div>
+    <div class="see-more" ng-if="!$ctrl.supporting.total_contributions">
+      No data on contributions
+    </div>
+
   </div>
   <div ng-if="$ctrl.supporting.total_expenditures" class="divided-section is-off-screen" when-visible="$ctrl.onVisible">
     <span class="text-serif text-grey-4">Money going out</span>


### PR DESCRIPTION
On the candidate page, add a link to the candidates contributors page (committee/:filer_id). At the moment, the page 404's since there's no contributor data in the backend for candidates. But once the backend data is there, this should be merge-able.

Resolves #162 