### PR TITLE
Use full-width container for committee page

### DIFF
--- a/app/components/appMainModule/committeePageModule/committeePage.html
+++ b/app/components/appMainModule/committeePageModule/committeePage.html
@@ -1,11 +1,11 @@
 
-<div class="fluid-container">
+<div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
             <odca-page-header page-title="{{committee.name}}"></odca-page-header>
         </div>
     </div>
-    <div class="row">
+    <div class="row bg-white">
         <div class="col-xs-12">
             <committee-listing committee="committee" contributions="contributions"></committee-listing>
         </div>

--- a/app/components/common/committeeListing/committeeListing.less
+++ b/app/components/common/committeeListing/committeeListing.less
@@ -1,7 +1,6 @@
 .committee-listing {    
     background-color: white;
     color: @core-grey-4;
-    padding: 1rem 4rem;
     margin-bottom: 1rem;
 
     .search-container {


### PR DESCRIPTION
As per conversation here, container should be full-width https://github.com/caciviclab/disclosure-frontend/pull/212#discussion_r81892648

At 1500px
![screenshot from 2016-10-07 08-26-51](https://cloud.githubusercontent.com/assets/509703/19195797/dc9ffd36-8c67-11e6-916a-6af0ff18be78.png)
