### PR TITLE
Add zero-width space to avoid long line

### DIFF
--- a/app/components/appMainModule/faqPageModule/faqPage.md
+++ b/app/components/appMainModule/faqPageModule/faqPage.md
@@ -108,7 +108,7 @@ E](http://www.fppc.ca.gov/content/dam/fppc/NS-Documents/TAD/Campaign%20Forms/460
 p24_
 
 
-### Campaign Paraphernalia/Miscellaneous (CMP)
+### Campaign Paraphernalia/&#x200b;Miscellaneous (CMP)
 
 Includes lawn signs, buttons, bumper stickers, T-shirts, potholders, etc.
 Includes costs of election night event.


### PR DESCRIPTION
This long-line doesn't break at the "/", so it widens the page and causes
a gutter. The zero-width space allows the line to break after the slash.

Related to #226