### PR TITLE
Override static backend for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ Url                                      | Description
 If you want to test against a development backend, you can set an environment
 variable
 
+    $ DISCLOSURE_STATIC_BACKEND='http://localhost:4567' gulp build
     $ DISCLOSURE_SWAGGER_SPEC='http://localhost:8000/docs/api-docs/' gulp build
 
 And the tests
 
+    $ DISCLOSURE_STATIC_BACKEND='http://localhost:4567' gulp test
     $ DISCLOSURE_SWAGGER_SPEC='http://localhost:8000/docs/api-docs/' gulp test
 
 

--- a/app/components/common/static/index.js
+++ b/app/components/common/static/index.js
@@ -3,12 +3,12 @@
 
 var angular = require('angular');
 
-var static_backend_url = 'https://disclosure-backend-static.herokuapp.com';
-
 angular.module('odca.static_api', [
     require('angular-resource')
   ])
-  .factory('static_api', function ($resource) {
+  .factory('static_api', function ($resource, settings) {
+    'ngInject';
+
     return {
       candidate: api_group('/candidate/:candidate_id', {
         supporting: {
@@ -51,7 +51,7 @@ angular.module('odca.static_api', [
     };
 
     function api_group(base_url, actions, defaultParams) {
-      var absolute_url = static_backend_url + base_url;
+      var absolute_url = settings.DISCLOSURE_STATIC_BACKEND + base_url;
       defaultParams = defaultParams || {};
 
       var resourceActions = {};

--- a/app/components/services/settings/index.js
+++ b/app/components/services/settings/index.js
@@ -14,6 +14,7 @@ angular.module('appMain.settings', [])
     // These values come from envify and are injected at build time
     var settings = {
       env: env,
+      DISCLOSURE_STATIC_BACKEND: process.env.DISCLOSURE_STATIC_BACKEND || 'https://disclosure-backend-static.herokuapp.com',
       DISCLOSURE_SWAGGER_SPEC: process.env.DISCLOSURE_SWAGGER_SPEC || 'https://disclosure-backend-static.herokuapp.com/docs/api-docs/'
     };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "browserify": {
     "transform": [
       "browserify-shim",
+      "envify",
       "partialify"
     ]
   },


### PR DESCRIPTION
Allows env variable `DISCLOSURE_STATIC_BACKEND` to override the static API so that
you can use a local static backend during development.

cc @mikeubell 