### PR TITLE
Remove redundant data

### DIFF
--- a/app/components/common/static/index.js
+++ b/app/components/common/static/index.js
@@ -11,13 +11,14 @@ angular.module('odca.static_api', [
 
     return {
       candidate: api_group('/candidate/:candidate_id', {
+        // all data is in one file
         supporting: {
           method: 'get',
-          url: '/supporting'
+          url: '/'
         },
         opposing: {
           method: 'get',
-          url: '/opposing'
+          url: '/'
         }
       }),
       committee: api_group('/committee/:filer_id', {


### PR DESCRIPTION
Since all the data is in the candidate index page, this removes fetching separate supporting/opposing pages.