### PR TITLE
Remove the CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.opendisclosure.io


### PR DESCRIPTION
Site is deprecated and we're ready to replace the domain with a new site!